### PR TITLE
Add build for port 2222

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,11 @@ jobs:
             --tag="$IMAGE_NAME_2222:latest" \
             --tag="$IMAGE_NAME_2222:$DATE_TAG"
 
+      - name: Test image
+        env:
+          SFTP_PORT: 2222
+        run: tests/run $IMAGE_NAME_2222:latest
+
       - name: Push images to Docker Hub registry
         if: github.ref == 'refs/heads/master'
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   IMAGE_NAME: ghcr.io/techonomydev/atmoz-sftp
+  IMAGE_NAME_2222: ghcr.io/techonomydev/atmoz-sftp-2222
 
 jobs:
   build:
@@ -56,4 +57,48 @@ jobs:
             -u "$GITHUB_ACTOR" --password-stdin
 
           docker push --all-tags $IMAGE_NAME
+          docker logout
+
+  build_2222:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true # for shunit2
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          ignore_paths: tests/shunit2
+
+      - name: Generate date tag
+        id: generate_date
+        shell: bash
+        run: echo "date-tag=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Build debian image
+        shell: bash
+        env:
+          DATE_TAG: ${{ steps.generate_date.outputs.date-tag }}
+        run: |
+          docker build . \
+            --pull=true \
+            --file=Dockerfile-port-2222 \
+            --tag="$IMAGE_NAME_2222:latest" \
+            --tag="$IMAGE_NAME_2222:$DATE_TAG"
+
+      - name: Test image
+        run: tests/run $IMAGE_NAME_2222:latest
+
+      - name: Push images to Docker Hub registry
+        if: github.ref == 'refs/heads/master'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_ACTOR: ${{ github.actor }}
+        run: |
+          echo "$GITHUB_TOKEN" | docker login ghcr.io \
+            -u "$GITHUB_ACTOR" --password-stdin
+
+          docker push --all-tags $IMAGE_NAME_2222
           docker logout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,9 +88,6 @@ jobs:
             --tag="$IMAGE_NAME_2222:latest" \
             --tag="$IMAGE_NAME_2222:$DATE_TAG"
 
-      - name: Test image
-        run: tests/run $IMAGE_NAME_2222:latest
-
       - name: Push images to Docker Hub registry
         if: github.ref == 'refs/heads/master'
         env:

--- a/Dockerfile-port-2222
+++ b/Dockerfile-port-2222
@@ -1,0 +1,19 @@
+FROM debian:bullseye
+
+# Steps done in one RUN layer:
+# - Install packages
+# - OpenSSH needs /var/run/sshd to run
+# - Remove generic host keys, entrypoint generates unique keys
+RUN apt-get update && \
+    apt-get -y install openssh-server && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /var/run/sshd && \
+    rm -f /etc/ssh/ssh_host_*key*
+
+COPY files/sshd_config_2222 /etc/ssh/sshd_config
+COPY files/create-sftp-user /usr/local/bin/
+COPY files/entrypoint /
+
+EXPOSE 2222
+
+ENTRYPOINT ["/entrypoint"]

--- a/files/sshd_config_2222
+++ b/files/sshd_config_2222
@@ -1,0 +1,25 @@
+# Secure defaults
+# See: https://stribika.github.io/2015/01/04/secure-secure-shell.html
+Protocol 2
+HostKey /etc/ssh/ssh_host_ed25519_key
+HostKey /etc/ssh/ssh_host_rsa_key
+
+# Faster connection
+# See: https://github.com/atmoz/sftp/issues/11
+UseDNS no
+
+# Limited access
+PermitRootLogin no
+X11Forwarding no
+AllowTcpForwarding no
+
+# Force sftp and chroot jail
+Subsystem sftp internal-sftp
+ForceCommand internal-sftp
+ChrootDirectory %h
+
+# Port 2222
+
+
+# Enable this for more logs
+#LogLevel VERBOSE

--- a/files/sshd_config_2222
+++ b/files/sshd_config_2222
@@ -18,8 +18,7 @@ Subsystem sftp internal-sftp
 ForceCommand internal-sftp
 ChrootDirectory %h
 
-# Port 2222
-
+Port 2222
 
 # Enable this for more logs
 #LogLevel VERBOSE

--- a/tests/run
+++ b/tests/run
@@ -13,6 +13,8 @@ sshHostEd25519Key="$tmpDir/ssh_host_ed25519_key"
 sshHostKeyMountArg="--volume=$sshHostEd25519Key:/etc/ssh/ssh_host_ed25519_key"
 sshKnownHosts="$tmpDir/known_hosts"
 
+SFTP_PORT=${SFTP_PORT:-"22"}
+
 if [ $UID != 0 ] && ! groups | grep -qw docker; then
     echo "Run with sudo/root or add user $USER to group 'docker'"
     exit 1
@@ -103,24 +105,26 @@ function runSftpCommands() {
 
     echo "$commands" | sftp \
         -i "$sshKeyPri" \
+        -P "$SFTP_PORT" \
         -oUserKnownHostsFile="$sshKnownHosts" \
         -b - "$user@$ip" \
         > "$redirect" 2>&1
 
     status=$?
+
     sleep 1 # wait for commands to finish
     return $status
 }
 
 function waitForServer() {
     containerName="$1"
-    echo -n "Waiting for $containerName to open port 22 ..."
+    echo -n "Waiting for $containerName to open port $SFTP_PORT ..."
 
     for _ in {1..30}; do
         sleep 1
         ip="$(getSftpIp "$containerName")"
         echo -n "."
-        if [ -n "$ip" ] && nc -z "$ip" 22; then
+        if [ -n "$ip" ] && nc -z "$ip" "$SFTP_PORT"; then
             echo " OPEN"
             return 0;
         fi
@@ -274,8 +278,16 @@ function testWriteAccessToAutocreatedDirs() {
 function testWriteAccessToLimitedChroot() {
     # Modified sshd_config with chrooted home subdir
     tmpConfig="$(mktemp)"
-    sed 's/^ChrootDirectory.*/ChrootDirectory %h\/sftp/' \
-        < "$testDir/../files/sshd_config" > "$tmpConfig"
+
+    
+
+    if [ "$SFTP_PORT" == "2222" ]; then
+        sed 's/^ChrootDirectory.*/ChrootDirectory %h\/sftp/' \
+            < "$testDir/../files/sshd_config_2222" > "$tmpConfig"
+    else
+        sed 's/^ChrootDirectory.*/ChrootDirectory %h\/sftp/' \
+            < "$testDir/../files/sshd_config" > "$tmpConfig"
+    fi
 
     # Set correct permissions on chroot
     tmpScript="$(mktemp)"


### PR DESCRIPTION
Atmoz SFTP build which defaults to port 2222. This is necesarry for hosting as a container in GCP compute instance, since container ports can not be mapped there. Port 22 is already in use in the compute engine for accessing the instance.